### PR TITLE
Fix typo in TLPMiniBatch momentum update

### DIFF
--- a/08a. Practical_NeuralNets with Bias.ipynb
+++ b/08a. Practical_NeuralNets with Bias.ipynb
@@ -218,7 +218,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -256,7 +256,7 @@
     "        self.b2 -= eta * gradb2\n",
     "\n",
     "        # update previous parameters \n",
-    "        self.rho_W1_prev, self.rho_W2_prev = rho_W1, rho_W2\n",
+    "        self._rho_W1_prev, self._rho_W2_prev = rho_W1, rho_W2\n",
     "\n",
     "    def _learning_rate_update(self, epoch):\n",
     "        # decrease learning rate at certain epochs\n",


### PR DESCRIPTION
In the function `_momentum_update` in TLPMiniBatch, the variables `self._rho_W1_prev` and `self._rho_W2_prev` are consistently used, except that the update mistakenly creates the new variables `self.rho_W1_prev` and `self.rho_W2_prev` instead. This PR corrects this by updating `self._rho_W1_prev` and `self._rho_W2_prev` to maintain consistency with the rest of the function.